### PR TITLE
Patch libsolv to not throw on subdir mismatch

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pavelzw @JohanMabille @SylvainCorlay @adriendelsalle @davidbrochart @wolfv
+* @JohanMabille @SylvainCorlay @adriendelsalle @davidbrochart @pavelzw @wolfv

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,7 +34,7 @@ CONDARC
 
 conda install --update-specs --yes --quiet --channel conda-forge \
     conda-build pip boa conda-forge-ci-setup=3
-conda update --update-specs --yes --quiet --channel conda-forge \
+conda install --update-specs --yes --quiet --channel conda-forge \
     conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -32,9 +32,9 @@ pkgs_dirs:
 CONDARC
 
 
-mamba install --update-specs --yes --quiet --channel conda-forge \
+conda install --update-specs --yes --quiet --channel conda-forge \
     conda-build pip boa conda-forge-ci-setup=3
-mamba update --update-specs --yes --quiet --channel conda-forge \
+conda update --update-specs --yes --quiet --channel conda-forge \
     conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc

--- a/README.md
+++ b/README.md
@@ -213,5 +213,6 @@ Feedstock Maintainers
 * [@SylvainCorlay](https://github.com/SylvainCorlay/)
 * [@adriendelsalle](https://github.com/adriendelsalle/)
 * [@davidbrochart](https://github.com/davidbrochart/)
+* [@pavelzw](https://github.com/pavelzw/)
 * [@wolfv](https://github.com/wolfv/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,10 @@ source:
   patches:
     - win_export_and_static_build.patch  # [win]
     - conda_variant_priorization.patch
+    - no_error_subdir_mismatch.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 

--- a/recipe/no_error_subdir_mismatch.patch
+++ b/recipe/no_error_subdir_mismatch.patch
@@ -1,26 +1,24 @@
 diff --git a/ext/repo_conda.c b/ext/repo_conda.c
-index 9211cbe..c6c0c45 100644
+index 9211cbe..c471039 100644
 --- a/ext/repo_conda.c
 +++ b/ext/repo_conda.c
-@@ -314,8 +314,8 @@ parse_package(struct parsedata *pd, struct solv_jsonparser *jp, char *kfn, char
+@@ -314,8 +314,7 @@ parse_package(struct parsedata *pd, struct solv_jsonparser *jp, char *kfn, char
    /* if we have a global subdir make sure that it matches */
    if (subdir && pd->subdir && strcmp(subdir, pd->subdir) != 0)
      {
 -      pd->error = "subdir mismatch";
 -      return JP_ERROR;
 +      printf("subdir mismatch\n");
-+      continue;
      }
  
    if (fn || kfn)
-@@ -402,8 +402,8 @@ parse_info(struct parsedata *pd, struct solv_jsonparser *jp)
+@@ -402,8 +401,7 @@ parse_info(struct parsedata *pd, struct solv_jsonparser *jp)
  	    pd->subdir = strdup(jp->value);
  	  else if (strcmp(pd->subdir, jp->value))
  	    {
 -	      pd->error = "subdir mismatch";
 -	      return JP_ERROR;
 +	      printf("warning: subdir mismatch\n");
-+	      continue;
  	    }
  	}
      }

--- a/recipe/no_error_subdir_mismatch.patch
+++ b/recipe/no_error_subdir_mismatch.patch
@@ -1,3 +1,5 @@
+diff --git a/ext/repo_conda.c b/ext/repo_conda.c
+index 9211cbe..e411527 100644
 --- a/ext/repo_conda.c
 +++ b/ext/repo_conda.c
 @@ -314,8 +314,7 @@ parse_package(struct parsedata *pd, struct solv_jsonparser *jp, char *kfn, char
@@ -19,3 +21,4 @@
 +             printf("warning: subdir mismatch.\n");
             }
         }
+     }

--- a/recipe/no_error_subdir_mismatch.patch
+++ b/recipe/no_error_subdir_mismatch.patch
@@ -1,5 +1,5 @@
 diff --git a/ext/repo_conda.c b/ext/repo_conda.c
-index 9211cbe..e411527 100644
+index 9211cbe..a9fab34 100644
 --- a/ext/repo_conda.c
 +++ b/ext/repo_conda.c
 @@ -314,8 +314,7 @@ parse_package(struct parsedata *pd, struct solv_jsonparser *jp, char *kfn, char

--- a/recipe/no_error_subdir_mismatch.patch
+++ b/recipe/no_error_subdir_mismatch.patch
@@ -1,0 +1,21 @@
+--- a/ext/repo_conda.c
++++ b/ext/repo_conda.c
+@@ -314,8 +314,7 @@ parse_package(struct parsedata *pd, struct solv_jsonparser *jp, char *kfn, char
+   /* if we have a global subdir make sure that it matches */
+   if (subdir && pd->subdir && strcmp(subdir, pd->subdir) != 0)
+     {
+-      pd->error = "subdir mismatch";
+-      return JP_ERROR;
++      printf("warning: subdir mismatch.\n");
+     }
+
+   if (fn || kfn)
+@@ -402,8 +401,7 @@ parse_info(struct parsedata *pd, struct solv_jsonparser *jp)
+            pd->subdir = strdup(jp->value);
+          else if (strcmp(pd->subdir, jp->value))
+            {
+-             pd->error = "subdir mismatch";
+-             return JP_ERROR;
++             printf("warning: subdir mismatch.\n");
+            }
+        }

--- a/recipe/no_error_subdir_mismatch.patch
+++ b/recipe/no_error_subdir_mismatch.patch
@@ -1,24 +1,26 @@
 diff --git a/ext/repo_conda.c b/ext/repo_conda.c
-index 9211cbe..a9fab34 100644
+index 9211cbe..c6c0c45 100644
 --- a/ext/repo_conda.c
 +++ b/ext/repo_conda.c
-@@ -314,8 +314,7 @@ parse_package(struct parsedata *pd, struct solv_jsonparser *jp, char *kfn, char
+@@ -314,8 +314,8 @@ parse_package(struct parsedata *pd, struct solv_jsonparser *jp, char *kfn, char
    /* if we have a global subdir make sure that it matches */
    if (subdir && pd->subdir && strcmp(subdir, pd->subdir) != 0)
      {
 -      pd->error = "subdir mismatch";
 -      return JP_ERROR;
-+      printf("warning: subdir mismatch.\n");
++      printf("subdir mismatch\n");
++      continue;
      }
-
+ 
    if (fn || kfn)
-@@ -402,8 +401,7 @@ parse_info(struct parsedata *pd, struct solv_jsonparser *jp)
-            pd->subdir = strdup(jp->value);
-          else if (strcmp(pd->subdir, jp->value))
-            {
--             pd->error = "subdir mismatch";
--             return JP_ERROR;
-+             printf("warning: subdir mismatch.\n");
-            }
-        }
+@@ -402,8 +402,8 @@ parse_info(struct parsedata *pd, struct solv_jsonparser *jp)
+ 	    pd->subdir = strdup(jp->value);
+ 	  else if (strcmp(pd->subdir, jp->value))
+ 	    {
+-	      pd->error = "subdir mismatch";
+-	      return JP_ERROR;
++	      printf("warning: subdir mismatch\n");
++	      continue;
+ 	    }
+ 	}
      }


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Context: This PR is a step towards a proposed solution to fix https://github.com/mamba-org/mamba/issues/2363. The issue is manifesting as a global outage for any workflow that's using mamba/micromamba due to certain channels including packages that declare a subdir that's different from the repodata.json subdir it's found in.

<!--
Please add any other relevant info below:
-->
