### PR TITLE
patch `prune_dq_for_future_installed` out

### DIFF
--- a/recipe/do_not_prune_future_installed.patch
+++ b/recipe/do_not_prune_future_installed.patch
@@ -1,0 +1,20 @@
+diff --git a/src/solver.c b/src/solver.c
+index bdce9a9d..9bda624b 100644
+--- a/src/solver.c
++++ b/src/solver.c
+@@ -1369,9 +1369,12 @@ selectandinstall(Solver *solv, int level, Queue *dq, int disablerules, Id ruleid
+    * do some special pruning and supplements ordering */
+   if (dq->count > 1 && solv->do_extra_reordering)
+     {
+-      prune_dq_for_future_installed(solv, dq);
+-      if (dq->count > 1)
+-	reorder_dq_for_future_installed(solv, level, dq);
++      // causes non-deterministic behavior in some solves
++      // see https://github.com/conda/conda-libmamba-solver/issues/317
++      // reverts part of https://github.com/openSUSE/libsolv/commit/4edf4e62db655734d0
++      // prune_dq_for_future_installed(solv, dq);
++      // if (dq->count > 1)
++       reorder_dq_for_future_installed(solv, level, dq);
+     }
+   /* check if the candidates are all connected via yumobs rules */
+   if (dq->count > 1 && solv->yumobsrules_end > solv->yumobsrules)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,9 +22,10 @@ source:
     - win_export_and_static_build.patch  # [win]
     - conda_variant_priorization.patch
     - no_error_subdir_mismatch.patch
+    - do_not_prune_future_installed.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Fixes https://github.com/conda/conda-libmamba-solver/issues/317. See there for a beautiful journey down the rabbit hole.

TLDR: https://github.com/openSUSE/libsolv/commit/4edf4e62db655734d0c362c59f8cb1987ef6b164 seems to introduce non-deterministic behaviour that manifests in some tests in the conda test suite with alternative solutions. This reverts part of that PR so the new functions are not called in the main method.